### PR TITLE
add working directory input

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Note: Since the action is not interactive, it invokes the CLI via `clojure` rath
 
 **Default:** none are set
 
+### `working-directory`
+
+**Optional:** In case the clojure command should not be executed in the root directory, you can specify another working directory.
+
 ### `ssh-key`
 
 **Optional:** A GitHub secret that has the The SSH key needed to access code from other private repositories (eg `${{ secrets.SSH_PRIVATE_KEY }}`)

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
   ssh-key:
     description: 'GitHub secret with the SSH private key to access your private repositories'
     required: false
+  working-directory:
+    description: 'Working directoy in which to execute the clojure command'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -22,4 +25,5 @@ runs:
     - ${{ inputs.alias }}
     - ${{ inputs.java-opts }}
     - ${{ inputs.ssh-key }}
+    - ${{ inputs.working-directory }}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,9 +38,17 @@ fi
 # Working Directory
 workingDirectory=$4
 
+set +e
 if [[ -n $workingDirectory ]]; then
-  cd "$workingDirectory"
+  if [[ -d $workingDirectory ]]; then
+    cd "$workingDirectory"
+  else
+    echo "ERROR: working-directory $workingDirectory does not exist"
+    exit 1
+  fi
 fi
+
+set -e
 
 # Log the actions
 set -x

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,6 +35,13 @@ then
 
 fi
 
+# Working Directory
+workingDirectory=$4
+
+if [[ -n $workingDirectory ]]; then
+  cd "$workingDirectory"
+fi
+
 # Log the actions
 set -x
 


### PR DESCRIPTION
In case you want to run the clojure task in another directory than the root of the github action context, working-directory allows you to specify this directory.